### PR TITLE
chore: Update director endpoint naming

### DIFF
--- a/charts/currents/templates/_common.tpl
+++ b/charts/currents/templates/_common.tpl
@@ -158,7 +158,7 @@ Create the name of the service account to use
 
 {{- define "currents.URLConfigEnv" -}}
 - name: GITLAB_REDIRECT_URL
-  value: {{ printf "%s/integrations/gitlab/callback" (include "currents.url" (dict "context" . "input" .Values.currents.domains.apiHost)) }}
+  value: {{ printf "%s/integrations/gitlab/callback" (include "currents.url" (dict "context" . "input" .Values.currents.domains.recordApiHost)) }}
 - name: APP_BASE_URL
   value: {{ include "currents.url" (dict "context" . "input"  .Values.currents.domains.appHost) }}
 - name: DASHBOARD_URL

--- a/charts/currents/values.yaml
+++ b/charts/currents/values.yaml
@@ -78,8 +78,8 @@ currents:
     https: true
     # This is the host for the app
     appHost: currents-app.localhost
-    # This is the host for the api
-    apiHost: currents-api.localhost
+    # This is the host for the recording endpoint that the test reporters communicate with
+    recordApiHost: currents-record.localhost
   rootUser:
     email: 'admin@{{ .Values.currents.domains.appHost }}'
   imageTag: staging-x86_64
@@ -224,7 +224,7 @@ director:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:
-      - host: "{{ .Values.currents.domains.apiHost }}"
+      - host: "{{ .Values.currents.domains.recordApiHost }}"
         paths:
           - path: /
             pathType: Prefix

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the `currents` chart an
 | `currents.imageTag` | Image tag for Currents components | `staging-x86_64` |
 | `currents.domains.https` | Whether to use https protocol for links to the domains | `true` |
 | `currents.domains.appHost` | Base domain for the application | `"currents-app.localhost"` |
-| `currents.domains.apiHost` | Base domain for the test reporter client api | `"currents-app.localhost"` |
+| `currents.domains.recordApiHost` | Base domain for the test reporter client api | `"currents-record.localhost"` |
 | `currents.email.smtp` | SMTP configuration for email | See `values.yaml` |
 | `currents.rootUser.email` | Email address for the root org user | `root@currents.local` |
 | `currents.ingress.enabled` | Enable ingress for Currents | `false` |

--- a/docs/eks/quickstart.md
+++ b/docs/eks/quickstart.md
@@ -355,9 +355,9 @@ Configure and install the Currents Helm Chart once all the services are ready.
      domains:
        https: true
        # This is the domain you want to access the app via the webbrowser
-       appHost: currents-app.eks.currents-sandbox.work
+       appHost: currents.eks.currents-sandbox.work
        # This is the domain used to reach the director, called from the test reporters
-       apiHost: currents-api.eks.currents-sandbox.work
+       recordApiHost: currents-record.eks.currents-sandbox.work
      email:
        smtp:
          # The domain in the from address needs to be one your SMTP server is authorized to send from
@@ -414,8 +414,8 @@ Configure and install the Currents Helm Chart once all the services are ready.
          alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:"
          alb.ingress.kubernetes.io/target-type: ip
        hosts:
-         # Set the Director DNS name, often called API
-         - host: "{{ .Values.currents.domains.apiHost }}"
+         # Set the Director DNS name, often called the RECORD API
+         - host: "{{ .Values.currents.domains.recordApiHost }}"
            paths:
              - path: /
                pathType: Prefix
@@ -463,5 +463,5 @@ And you can have Currents Test reporters access the `director` DNS by setting th
 
 For example:
 ```sh
-CURRENTS_API_URL=https://currents-api.eks.example.com npx pwc --key <your-key> --project-id <your projectid>
+CURRENTS_API_URL=https://currents-record.eks.example.com npx pwc --key <your-key> --project-id <your projectid>
 ```

--- a/samples/eks/eks-config.yaml
+++ b/samples/eks/eks-config.yaml
@@ -5,8 +5,8 @@ global:
 currents:
   domains:
     https: true
-    appHost: currents-app.eks.currents-sandbox.work
-    apiHost: currents-api.eks.currents-sandbox.work
+    appHost: currents.eks.currents-sandbox.work
+    recordApiHost: currents-record.eks.currents-sandbox.work
   email:
     smtp:
       # from: "Currents Report <report@{{ .Values.currents.domains.appHost }}>"
@@ -53,7 +53,7 @@ director:
       alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:761136292957:certificate/0d3489f4-6b3e-4651-9538-4f6377fadeaa"
       alb.ingress.kubernetes.io/target-type: ip
     hosts:
-      - host: "{{ .Values.currents.domains.apiHost }}"
+      - host: "{{ .Values.currents.domains.recordApiHost }}"
         paths:
           - path: /
             pathType: Prefix

--- a/samples/local/chart-config.yaml
+++ b/samples/local/chart-config.yaml
@@ -14,7 +14,7 @@ currents:
   domains:
     https: false
     appHost: currents-app.localhost
-    apiHost: currents-api.localhost
+    recordApiHost: currents-record.localhost
   imageTag: staging-aarch64
   apiJwtToken:
     secretName: currents-api-jwt-token


### PR DESCRIPTION
- Call it the record endpoint instead of client api

For some reason I kept calling it API, (even though it's the `cy` endpoint in prod). I don't think we want to call it cy, but let's call it `record`. To go along with the fact that you need a record key to communicate with it.