### PR TITLE
chore: always sync gh pages docs on pushes to main

### DIFF
--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -1,7 +1,9 @@
 name: Sync Docs to GH Pages
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
- Simplifies the steps for other team members