### PR TITLE
[CSR-2482] chore: generate the configuration documents from the values

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -1,0 +1,29 @@
+name: Docs check
+
+on: pull_request
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Ensure documentation is updated
+        uses: docker://jnorwood/helm-docs:latest
+        with:
+          args: "-t docs/configuration.md.gotmpl -s file -o ../../docs/configuration.md"
+      - name: Check for changes
+        run: |
+          if git diff --exit-code; then
+            echo -e "\n####### Git is clean\n"
+          else
+            git status
+            echo -e "\n####### Git changes detected! Be sure to run ./scripts/build-docs.sh and commit !!!\n"
+            exit 1
+          fi

--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -22,7 +22,6 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/charts/currents/values.yaml
+++ b/charts/currents/values.yaml
@@ -1,39 +1,181 @@
 # Default values for currents.
 
-# This is to override the chart name.
-# nameOverride: "my-currents"
-# fullnameOverride: "my-currents"
+# nameOverride -- a string to override the chart name
+# nameOverride:
+# fullnameOverride:
 
+# Currents App Configuration
+currents:
+  domains:
+    # -- The host for the app
+    # @section -- Required
+    appHost: currents-app.localhost
+    # -- The host for the recording endpoint that the test reporters communicate with
+    # @section -- Required
+    recordApiHost: currents-record.localhost
+    # -- Whether to use https or http
+    # @section -- Frequently Used
+    https: true
+  rootUser:
+    # -- The email address of the root user
+    email: 'admin@{{ .Values.currents.domains.appHost }}'
+  # -- The image tag to use for the Currents images
+  imageTag: 2025-04-08-001
+  email:
+    smtp:
+      # -- The SMTP server port to use
+      port: 587
+      # -- The K8s secret key to use for the SMTP username
+      # @section -- Frequently Used
+      secretUserKey: username
+      # -- The K8s secret key to use for the SMTP password
+      # @section -- Frequently Used
+      secretPasswordKey: password
+      # -- (tpl/string) The email address to send from
+      from: "Currents Report <report@{{ .Values.currents.domains.appHost }}>"
+      # -- the SMTP server to use
+      # @section -- Required
+      host: ""
+      # -- K8s secret to use for the SMTP username/password
+      # @section -- Required
+      secretName: ""
+      # -- Whether the SMTP server uses TLS
+      tls: false
+  ingress:
+    # -- Whether to enable the both default ingresses (server, and director)
+    enabled: false
+  apiJwtToken:
+    # -- The K8s secret to use for the JWT token
+    # @section -- Required
+    secretName: ""
+    # -- The K8s secret key to use for the JWT token
+    # @section -- Frequently Used
+    key: token
+    # -- How often to expire session tokens signed by the JWT token 
+    expiry: 1d
+  apiInternalToken:
+    # -- The K8s secret to use for the internal API token
+    # @section -- Required
+    secretName: ""
+    # -- The K8s secret key to use for the internal API token
+    # @section -- Frequently Used
+    key: token
+  redis:
+    # -- (tpl) set the redis hostname to talk to
+    # @default -- `{{ .Release.Name }}-redis-master`
+    host: "{{ .Release.Name }}-redis-master"
+  elastic:
+    datastreams:
+      # -- The elasticsearch index to use for instances
+      instances: currents_dev_instances
+      # -- The elasticsearch index to use for tests
+      tests: currents_dev_tests
+      # -- The elasticsearch index to use for runs
+      runs: currents_dev_runs
+    admin:
+      # -- The elasticsearch admin username (used to manage the indexes)
+      # @section -- Frequently Used
+      username: elastic
+      # -- The k8s secret to use for the admin password
+      # @section -- Required
+      secretName: ""
+      # -- The k8s secret key to use for the admin password
+      # @section -- Required
+      secretKey: ""
+    apiUser:
+      # -- The k8s secret to use for the elasticsearch api key
+      # @section -- Required
+      secretName: ""
+      # -- The k8s secret key to use for the elasticsearch api ID
+      # @section -- Frequently Used
+      idKey: apiId
+      # -- The k8s secret key to use for the elasticsearch api key
+      # @section -- Frequently Used
+      secretKey: apiKey
+    tls:
+      # -- Whether to use TLS for the elasticsearch connection
+      # @section -- Frequently Used
+      enabled: true
+    # -- The elasticsearch host to use
+    # @section -- Required
+    host: ""
+    # -- The elasticsearch port to use
+    port: 9200
+  objectStorage:
+    # -- The object storage endpoint to use
+    # @section -- Required
+    endpoint: ""
+    # -- The object storage internal endpoint to use (for internal communication)
+    internalEndpoint: ""
+    # -- The K8s secret to use for the object storage access key
+    # @section -- Required
+    secretName: ""
+    # -- The K8s secret key to use for the object storage access key ID
+    # @section -- Frequently Used
+    secretIdKey: keyId
+    # -- The K8s secret key to use for the object storage secret access key
+    # @section -- Frequently Used
+    secretAccessKey: keySecret
+    # -- The object storage bucket to use
+    # @section -- Required
+    bucket: ""
+    # -- Whether to use path style access for the object storage
+    pathStyle: false
+  logger:
+    # -- The coralogix API endpoint to use
+    apiEndpoint: ""
+    # -- The k8s secret to use for the coralogix private key
+    apiSecretName: ""
+    # -- The k8s secret key to use for the coralogix private key
+    apiSecretKey: apiKey
+  mongoConnection:
+    # -- The K8s secret to use for the MongoDB connection string
+    # @section -- Required
+    secretName: ""
+    # -- The K8s secret key to use for the MongoDB connection string
+    # @section -- Required
+    key: ""
+  gitlab:
+    state:
+      # -- The K8s secret to use for the GitLab state key
+      # @section -- Required
+      secretName: ""
+      # -- The K8s secret key to use for the GitLab state key
+      # @section -- Required
+      secretKey: ""
+# END Currents App Configuration
+
+# Global Configuration 
+# applied to all Chart resources
 global:
-  # Reference to one or more secrets to be used when pulling images.
-  # For more information, see [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
-  #
-  # For example:
+  # -- Reference to one or more secrets to be used when pulling images.
+  # [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+  # @section -- Frequently Used
+  imagePullSecrets: []
   #  imagePullSecrets:
   #    - name: "image-pull-secret"
-  imagePullSecrets: []
+  # -- The image pull policy to use for all images
   imagePullPolicy: IfNotPresent
-  # Labels to apply to all resources.
+  # -- Labels to apply to all resources.
   additionalLabels: {}
-  # This is for setting Kubernetes Annotations to a Pod.
-  # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  # -- This is for setting Kubernetes Annotations to a Pod
   podAnnotations: {}
-  # Additional environment variables to pass to binary.
-  # For example:
+  # -- Additional environment variables to pass to binary.
+  env: []
   #  env:
   #  - name: SOME_VAR
   #    value: 'some value'
-  env: []
-  # Container Security Context to be set on the pods
-  # For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+  # -- (dict) Container Security Context to be set on the pods
+  # [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
         - ALL
     readOnlyRootFilesystem: true
-  # Pod Security Context.
-  # For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+  # -- (dict) Pod Security Context.
+  # [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   securityContext:
     runAsNonRoot: true
     fsGroup: 1000
@@ -41,145 +183,82 @@ global:
     fsGroupChangePolicy: "OnRootMismatch"
     seccompProfile:
       type: RuntimeDefault
-  # The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).
-  # revisionHistoryLimit: 1
-
-  # The optional priority class to be used for the currents pods.
+  # -- The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10).
+  revisionHistoryLimit:
+  # -- The optional priority class to be used for the currents pods.
   priorityClassName: ""
-  # Additional volumes on the output Deployment definition.
+  # -- Additional volumes on the output Deployment definition.
   volumes: []
   # - name: foo
   #   secret:
   #     secretName: mysecret
   #     optional: false
 
-  # Additional volumeMounts on the output Deployment definition.
+  # -- Additional volumeMounts on the output Deployment definition.
   volumeMounts: []
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
 
-  # This default ensures that Pods are only scheduled to Linux nodes.
+  # -- This default ensures that Pods are only scheduled to Linux nodes.
   # It prevents Pods being scheduled to Windows nodes in a mixed OS cluster.
   nodeSelector:
     kubernetes.io/os: linux
   tolerations: []
   affinity: {}
-currents:
-  domains:
-    https: true
-    # This is the host for the app
-    appHost: currents-app.localhost
-    # This is the host for the recording endpoint that the test reporters communicate with
-    recordApiHost: currents-record.localhost
-  rootUser:
-    email: 'admin@{{ .Values.currents.domains.appHost }}'
-  imageTag: 2025-04-08-001
-  email:
-    smtp:
-      port: 587
-      secretUserKey: username
-      secretPasswordKey: password
-      from: "Currents Report <report@{{ .Values.currents.domains.appHost }}>"
-      # host: smtp.mailgun.org
-      # secretName: currents-email-smtp
-      # tls: false
-  ingress:
-    enabled: false
-  apiJwtToken:
-    # secretName: currents-api-jwt-token
-    key: token
-    expiry: 1d
-  apiInternalToken:
-    # secretName: currents-api-internal-token
-    key: token
-  redis:
-    # -- set the redis hostname to talk to
-    # @default -- `{{ .Release.Name }}-redis-master`
-    host: "{{ .Release.Name }}-redis-master"
-    password: ""
-  elastic:
-    datastreams:
-      instances: currents_dev_instances
-      tests: currents_dev_tests
-      runs: currents_dev_runs
-    admin:
-      username: elastic
-      # secretName:
-      # secretKey:
-    apiUser:
-      # secretName:
-      idKey: apiId
-      secretKey: apiKey
-    tls:
-      enabled: true
-    host: ""
-    port: 9200
-  objectStorage:
-    # endpoint: ""
-    # internalEndpoint: ""
-    # secretName: ""
-    secretIdKey: keyId
-    secretAccessKey: keySecret
-    # bucket: ""
-    # pathStyle: false
-  logger:
-    apiEndpoint: ""
-    apiSecretName: ""
-    apiSecretKey: apiKey
-  mongoConnection: {}
-  gitlab:
-    state: {}
-    # secretName: ''
-    # secretKey: ''
+# END Global Configuration 
+
+# Director Configuration
 director:
   name: director
   replicas: 1
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
-    # The container registry to pull the manager image from.
+    # -- The container registry to pull the manager image from.
     registry: 513558712013.dkr.ecr.us-east-1.amazonaws.com
-    # The container image for Currents Director.
+    # -- The container image for Currents Director.
     repository: currents/on-prem/director
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion is used.
-    # tag: vX.Y.Z
-
-    # Setting a digest will override any tag.
+    # -- Override the image tag to deploy by setting this variable.
+    tag: ""
+    # -- Setting a digest will override any tag.
+    digest: ""
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
-    # defaults to global.image.pullPolicy
+    # -- default to the same as global.image.pullPolicy
     pullPolicy: ""
-  # Deployment update strategy for Currents deployment.
-  # For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
-  #
-  # For example:
+  # -- Deployment update strategy for Currents deployment.
+  # [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+  deploymentStrategy: {}
   #  strategy:
   #    type: RollingUpdate
   #    rollingUpdate:
   #      maxSurge: 0
   #      maxUnavailable: 1
-  deploymentStrategy: {}
+
+  # -- Env variables to pass to the container
   env: []
+  # -- Additional volumes on the output Deployment definition.
   volumes: []
+  # -- Additional volumeMounts on the output Deployment definition.
   volumeMounts: []
+  # -- Liveness probe to check if the container is alive
   livenessProbe:
     httpGet:
       path: /
       port: http
+  # -- Readiness probe to check if the container is ready
   readinessProbe:
     httpGet:
       path: /
       port: http
-  # Resources to provide
-  #
-  # For example:
+  # -- Resources to provide
+  # [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  # @section -- Frequently Used
+  resources: {}
   #  requests:
   #    cpu: 10m
   #    memory: 32Mi
-  #
-  # For more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
-  resources: {}
+
   # -- [Node selector]
   # @default -- `{}` (defaults to global.nodeSelector)
   nodeSelector: {}
@@ -189,76 +268,91 @@ director:
   # -- Assign custom [affinity] rules to the deployment
   # @default -- `{}` (defaults to the global.affinity preset)
   affinity: {}
-  # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+  # -- This is for setting up a service [more information](https://kubernetes.io/docs/concepts/services-networking/service/)
   service:
-    # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
-    # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
     port: 1234
-  # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
   ingress:
+    # -- Whether to enable the director ingress
+    # @default -- `false` (but can also be turned on by currents.ingress.enabled)
+    # @section -- Frequently Used
     enabled: false
-    # className: ""
+    # -- The ingress class to use
+    # @section -- Frequently Used
+    className: ""
+    # -- Annotations to add to the ingress
+    # @section -- Frequently Used
     annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+    # -- The hosts to use for the ingress
+    # @default -- see [values.yaml] for default values
+    # @section -- Frequently Used
     hosts:
       - host: "{{ .Values.currents.domains.recordApiHost }}"
         paths:
           - path: /
             pathType: Prefix
+    # -- The TLS configuration for the ingress
+    # @default -- see [values.yaml] for default values
+    # @section -- Frequently Used
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+# END Director Configuration
+
+# Server Configuration
 server:
   name: server
   replicas: 1
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
-    # The container registry to pull the manager image from.
+    # -- The container registry to pull the manager image from
     registry: 513558712013.dkr.ecr.us-east-1.amazonaws.com
-    # The container image for Currents Server API.
+    # -- The container image for Currents Server API
     repository: currents/on-prem/api
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion is used.
-    # tag: vX.Y.Z
-
-    # Setting a digest will override any tag.
+    # -- Override the image tag to deploy by setting this variable
+    tag: ""
+    # -- Setting a digest will override any tag
+    digest: ""
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
-    # defaults to global.image.pullPolicy
+    # -- defaults to global.image.pullPolicy
     pullPolicy: ""
-  # Deployment update strategy for Currents deployment.
-  # For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
-  #
-  # For example:
+  # -- Deployment update strategy for Currents deployment
+  deploymentStrategy: {}
   #  strategy:
   #    type: RollingUpdate
   #    rollingUpdate:
   #      maxSurge: 0
   #      maxUnavailable: 1
-  deploymentStrategy: {}
+
+  # -- Env variables to pass to the container
   env: []
+  # -- Additional volumes on the output Deployment definition
   volumes: []
+  # -- Additional volumeMounts on the output Deployment definition
   volumeMounts: []
+  # -- Liveness probe to check if the container is alive
   livenessProbe:
     httpGet:
       path: /
       port: http
+  # -- Readiness probe to check if the container is ready
   readinessProbe:
     httpGet:
       path: /
       port: http
-  # Resources to provide
-  #
-  # For example:
+  # -- Resources to provide
+  # [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  # @section -- Frequently Used
+  resources: {}
   #  requests:
   #    cpu: 10m
   #    memory: 32Mi
-  #
-  # For more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
-  resources: {}
+
   # -- [Node selector]
   # @default -- `{}` (defaults to global.nodeSelector)
   nodeSelector: {}
@@ -268,62 +362,92 @@ server:
   # -- Assign custom [affinity] rules to the deployment
   # @default -- `{}` (defaults to the global.affinity preset)
   affinity: {}
-  # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+  # -- This is for setting up a service [more information](https://kubernetes.io/docs/concepts/services-networking/service/)
   service:
-    # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
-    # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
     port: 4000
   # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
   ingress:
+    # -- Whether to enable the server ingress
+    # @default -- `false` (but can also be turned on by currents.ingress.enabled)
+    # @section -- Frequently Used
     enabled: false
-    # className: ""
+    # -- The ingress class to use
+    # @section -- Frequently Used
+    className: ""
+    # -- Annotations to add to the ingress
+    # @section -- Frequently Used
     annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+    # -- The hosts to use for the ingress
+    # @default -- see [values.yaml] for default values
+    # @section -- Frequently Used
     hosts:
       - host: "{{ .Values.currents.domains.appHost }}"
         paths:
           - path: /
             pathType: Prefix
+    # -- The TLS configuration for the ingress
+    # @default -- see [values.yaml] for default values
+    # @section -- Frequently Used
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+# Server Configuration
+
+# Writer Configuration
 writer:
   name: writer
   replicas: 1
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
-    # The container registry to pull the manager image from.
+    # The container registry to pull the manager image from
     registry: 513558712013.dkr.ecr.us-east-1.amazonaws.com
     # The container image for Currents Server API.
     repository: currents/on-prem/writer
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion is used.
-    # tag: vX.Y.Z
-
-    # Setting a digest will override any tag.
+    # -- Override the image tag to deploy by setting this variable
+    tag: ""
+    # -- Setting a digest will override any tag
+    digest: ""
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
-    # defaults to global.image.pullPolicy
+    # -- defaults to global.image.pullPolicy
     pullPolicy: ""
+  # -- Deployment update strategy for Currents deployment
   deploymentStrategy: {}
+  #  strategy:
+  #    type: RollingUpdate
+  #    rollingUpdate:
+  #      maxSurge: 0
+  #      maxUnavailable: 1
+
+  # -- Env variables to pass to the container
   env: []
+  # -- Additional volumes on the output Deployment definition
   volumes: []
+  # -- Additional volumeMounts on the output Deployment definition
   volumeMounts: []
+  # -- Liveness probe to check if the container is alive
   livenessProbe:
     exec:
       command:
         - ./node_modules/.bin/pm2
         - show
         - writer-service
+  # -- Readiness probe to check if the container is ready
   readinessProbe:
     exec:
       command:
         - ./node_modules/.bin/pm2
         - show
         - writer-service
+  # -- Resources to provide
+  # [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  # @section -- Frequently Used
+  # @default -- `{}` (defaults to global.resources)
   resources: {}
   # -- [Node selector]
   # @default -- `{}` (defaults to global.nodeSelector)
@@ -334,24 +458,28 @@ writer:
   # -- Assign custom [affinity] rules to the deployment
   # @default -- `{}` (defaults to the global.affinity preset)
   affinity: {}
+# END Writer Configuration
+
+# Scheduler Configuration
 scheduler:
   name: scheduler
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
-    # The container registry to pull the manager image from.
+    # -- The container registry to pull the manager image from
     registry: 513558712013.dkr.ecr.us-east-1.amazonaws.com
-    # The container image for Currents Server API.
+    # -- The container image for Currents Server API
     repository: currents/on-prem/scheduler
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion is used.
-    # tag: vX.Y.Z
-
-    # Setting a digest will override any tag.
+    # -- Override the image tag to deploy by setting this variable
+    tag: ""
+    # -- Setting a digest will override any tag
+    digest: ""
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
-    # defaults to global.image.pullPolicy
+    # -- defaults to global.image.pullPolicy
     pullPolicy: ""
   startup:
+    # -- Persistence settings used to optimize startup tasks (avoid rerun startup tasks on restart)
+    # @default -- See [values.yaml] for default values
     persistence:
       accessMode: ReadWriteOnce
       size: 10Mi
@@ -360,33 +488,34 @@ scheduler:
       # volumeName:
       matchLabels: {}
       matchExpressions: []
-  # Deployment update strategy for Currents deployment.
-  # For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
+  # -- Deployment update strategy for Currents deployment.
+  # [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
   deploymentStrategy:
     type: Recreate
+  # -- Env variables to pass to the container
   env: []
+  # -- Additional volumes on the output Deployment definition
   volumes: []
+  # -- Additional volumeMounts on the output Deployment definition
   volumeMounts: []
+  # -- Liveness probe to check if the container is alive
   livenessProbe:
     exec:
       command:
         - ./node_modules/.bin/pm2
         - show
         - dist
+  # -- Readiness probe to check if the container is ready
   readinessProbe:
     exec:
       command:
         - ./node_modules/.bin/pm2
         - show
         - dist
-  # Resources to provide
-  #
-  # For example:
-  #  requests:
-  #    cpu: 10m
-  #    memory: 32Mi
-  #
-  # For more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+  # -- Resources to provide
+  # [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  # @section -- Frequently Used
+  # @default -- `{}` (defaults to global.resources)
   resources: {}
   # -- [Node selector]
   # @default -- `{}` (defaults to global.nodeSelector)
@@ -397,28 +526,40 @@ scheduler:
   # -- Assign custom [affinity] rules to the deployment
   # @default -- `{}` (defaults to the global.affinity preset)
   affinity: {}
+# END Scheduler Configuration
+
+# Change Streams Configuration
 changestreams:
   name: change-streams
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
   image:
-    # The container registry to pull the manager image from.
+    # -- The container registry to pull the manager image from.
     registry: 513558712013.dkr.ecr.us-east-1.amazonaws.com
-    # The container image for Currents Change Streams Image
+    # -- The container image for Currents Change Streams Image
     repository: currents/on-prem/change-streams
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion is used.
-    # tag: vX.Y.Z
-
-    # Setting a digest will override any tag.
+    # -- Override the image tag to deploy by setting this variable
+    tag: ""
+    # -- Setting a digest will override any tag
+    digest: ""
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
-    # defaults to global.image.pullPolicy
+    # -- defaults to global.image.pullPolicy
     pullPolicy: ""
+  # -- Deployment update strategy for Currents deployment.
+  # [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
   deploymentStrategy:
     type: Recreate
+  # -- Env variables to pass to the container
   env: []
+  # -- Additional volumes on the output Deployment definition
   volumes: []
+  # -- Additional volumeMounts on the output Deployment definition
   volumeMounts: []
+  # -- Liveness probe to check if the container is alive
+  # -- Resources to provide
+  # [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  # @section -- Frequently Used
+  # @default -- `{}` (defaults to global.resources)
   resources: {}
   # -- [Node selector]
   # @default -- `{}` (defaults to global.nodeSelector)
@@ -429,6 +570,9 @@ changestreams:
   # -- Assign custom [affinity] rules to the deployment
   # @default -- `{}` (defaults to the global.affinity preset)
   affinity: {}
+# END Change Streams Configuration
+
+# Webhooks Configuration
 webhooks:
   name: webhooks
   # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
@@ -437,32 +581,43 @@ webhooks:
     registry: 513558712013.dkr.ecr.us-east-1.amazonaws.com
     # The container image for Currents Webhooks Image
     repository: currents/on-prem/webhooks
-    # Override the image tag to deploy by setting this variable.
-    # If no value is set, the chart's appVersion is used.
-    # tag: vX.Y.Z
-
-    # Setting a digest will override any tag.
+    # -- Override the image tag to deploy by setting this variable
+    tag: ""
+    # -- Setting a digest will override any tag
+    digest: ""
     # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 
-    # defaults to global.image.pullPolicy
+    # -- defaults to global.image.pullPolicy
     pullPolicy: ""
+  # -- Deployment update strategy for Currents deployment.
+  # [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
   deploymentStrategy:
     type: Recreate
+  # -- Env variables to pass to the container
   env: []
+  # -- Additional volumes on the output Deployment definition
   volumes: []
+  # -- Additional volumeMounts on the output Deployment definition
   volumeMounts: []
+  # -- Liveness probe to check if the container is alive
   livenessProbe:
     exec:
       command:
         - ./node_modules/.bin/pm2
         - show
         - dist
+  # -- Readiness probe to check if the container is ready
   readinessProbe:
     exec:
       command:
         - ./node_modules/.bin/pm2
         - show
         - dist
+  # -- Liveness probe to check if the container is alive
+  # -- Resources to provide
+  # [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  # @section -- Frequently Used
+  # @default -- `{}` (defaults to global.resources)
   resources: {}
   # -- [Node selector]
   # @default -- `{}` (defaults to global.nodeSelector)
@@ -473,25 +628,30 @@ webhooks:
   # -- Assign custom [affinity] rules to the deployment
   # @default -- `{}` (defaults to the global.affinity preset)
   affinity: {}
+# END Webhooks Configuration
+
+# Service Account Configuration
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  # name: ""
-
-  # Optional additional annotations to add to the Service Account. Templates are allowed for both keys and values.
-  # Example using templating:
+  # -- The name of the service account to use.
+  # @default -- If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # -- Optional additional annotations to add to the Service Account. Templates are allowed for both keys and values.
+  annotations: {}
   # annotations:
   #   "{{ .Chart.Name }}-helm-chart/version": "{{ .Chart.Version }}"
-  # annotations: {}
 
-  # Automatically mount a ServiceAccount's API credentials?
+  # -- Automatically mount a ServiceAccount's API credentials?
   automount: true
+# END Service Account Configuration
+
+# Redis Configuration
 # The included redis CAN be used in production, but you won't have high availability during version upgrades
 redis:
   # -- enable the Bitnami Redis chart. Refer to https://github.com/bitnami/charts/blob/main/bitnami/redis/ for possible values.
+  # @section -- Required
   enabled: false
   image:
     repository: redis/redis-stack-server
@@ -513,3 +673,4 @@ redis:
     resourcesPreset: "none"
   sysctl:
     resourcesPreset: "none"
+# END Redis Configuration

--- a/charts/currents/values.yaml
+++ b/charts/currents/values.yaml
@@ -51,7 +51,7 @@ currents:
     # -- The K8s secret key to use for the JWT token
     # @section -- Frequently Used
     key: token
-    # -- How often to expire session tokens signed by the JWT token 
+    # -- How often to expire session tokens signed by the JWT token
     expiry: 1d
   apiInternalToken:
     # -- The K8s secret to use for the internal API token
@@ -145,7 +145,7 @@ currents:
       secretKey: ""
 # END Currents App Configuration
 
-# Global Configuration 
+# Global Configuration
 # applied to all Chart resources
 global:
   # -- Reference to one or more secrets to be used when pulling images.
@@ -206,7 +206,7 @@ global:
     kubernetes.io/os: linux
   tolerations: []
   affinity: {}
-# END Global Configuration 
+# END Global Configuration
 
 # Director Configuration
 director:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,3 +211,5 @@ The following table lists the configurable parameters of the `currents` chart an
 | redis.metrics.resourcesPreset | string | `"none"` |  |
 | redis.volumePermissions.resourcesPreset | string | `"none"` |  |
 | redis.sysctl.resourcesPreset | string | `"none"` |  |
+
+[values.yaml]: https://github.com/currents-dev/helm-charts/blob/main/charts/currents/values.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the `currents` chart an
 | currents.email.smtp.from | tpl/string | `"Currents Report <report@{{ .Values.currents.domains.appHost }}>"` | The email address to send from |
 | currents.email.smtp.tls | bool | `false` | Whether the SMTP server uses TLS |
 | currents.ingress.enabled | bool | `false` | Whether to enable the both default ingresses (server, and director) |
-| currents.apiJwtToken.expiry | string | `"1d"` | How often to expire session tokens signed by the JWT token  |
+| currents.apiJwtToken.expiry | string | `"1d"` | How often to expire session tokens signed by the JWT token |
 | currents.redis.host | tpl | `{{ .Release.Name }}-redis-master` | set the redis hostname to talk to |
 | currents.elastic.datastreams.instances | string | `"currents_dev_instances"` | The elasticsearch index to use for instances |
 | currents.elastic.datastreams.tests | string | `"currents_dev_tests"` | The elasticsearch index to use for tests |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,44 +1,213 @@
 # Configuration Reference
 
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025-04-08-001](https://img.shields.io/badge/AppVersion-2025--04--08--001-informational?style=flat-square)
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.2.1 |
+
 The following table lists the configurable parameters of the `currents` chart and their default values:
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `global.imagePullSecrets` | Secrets for pulling images from private registries | `[]` |
-| `global.imagePullPolicy` | Image pull policy | `IfNotPresent` |
-| `global.additionalLabels` | Additional labels for all resources | `{}` |
-| `global.podAnnotations` | Annotations for pods | `{}` |
-| `global.env` | Global environment variables | `[]` |
-| `global.containerSecurityContext` | Security context for containers | See `values.yaml` |
-| `global.securityContext` | Security context for pods | See `values.yaml` |
-| `global.priorityClassName` | Priority class name for pods | `""` |
-| `global.volumes` | Additional volumes for pods | `[]` |
-| `global.volumeMounts` | Additional volume mounts for containers | `[]` |
-| `global.nodeSelector` | Node selector for pods | `{kubernetes.io/os: linux}` |
-| `global.tolerations` | Tolerations for pods | `[]` |
-| `global.affinity` | Affinity rules for pods | `{}` |
-| `currents.imageTag` | Image tag for Currents components | `staging-x86_64` |
-| `currents.domains.https` | Whether to use https protocol for links to the domains | `true` |
-| `currents.domains.appHost` | Base domain for the application | `"currents-app.localhost"` |
-| `currents.domains.recordApiHost` | Base domain for the test reporter client api | `"currents-record.localhost"` |
-| `currents.email.smtp` | SMTP configuration for email | See `values.yaml` |
-| `currents.rootUser.email` | Email address for the root org user | `root@currents.local` |
-| `currents.ingress.enabled` | Enable ingress for Currents | `false` |
-| `currents.apiJwtToken` | JWT token configuration | See `values.yaml` |
-| `currents.apiInternalToken` | Internal API token configuration | See `values.yaml` |
-| `currents.redis.host` | Redis host | `"{{ .Release.Name }}-redis-master"` |
-| `currents.elastic` | ElasticSearch configuration | See `values.yaml` |
-| `currents.objectStorage` | Object storage configuration | See `values.yaml` |
-| `currents.mongoConnection` | MongoDB connection configuration | `{}` |
-| `currents.gitlab` | GitLab integration configuration | See `values.yaml` |
-| `director` | Configuration for the Director component | See `values.yaml` |
-| `server` | Configuration for the Server component | See `values.yaml` |
-| `writer` | Configuration for the Writer component | See `values.yaml` |
-| `scheduler` | Configuration for the Scheduler component | See `values.yaml` |
-| `changestreams` | Configuration for the Change Streams component | See `values.yaml` |
-| `webhooks` | Configuration for the Webhooks component | See `values.yaml` |
-| `serviceAccount.create` | Create a service account | `true` |
-| `serviceAccount.name` | Name of the service account | `""` |
-| `redis.enabled` | Enable Redis | `false` |
+## Values
 
-For detailed descriptions of each parameter, refer to the `values.yaml` file in the chart.
+### Required
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| currents.domains.appHost | string | `"currents-app.localhost"` | The host for the app |
+| currents.domains.recordApiHost | string | `"currents-record.localhost"` | The host for the recording endpoint that the test reporters communicate with |
+| currents.email.smtp.host | string | `""` | the SMTP server to use |
+| currents.email.smtp.secretName | string | `""` | K8s secret to use for the SMTP username/password |
+| currents.apiJwtToken.secretName | string | `""` | The K8s secret to use for the JWT token |
+| currents.apiInternalToken.secretName | string | `""` | The K8s secret to use for the internal API token |
+| currents.elastic.admin.secretName | string | `""` | The k8s secret to use for the admin password |
+| currents.elastic.admin.secretKey | string | `""` | The k8s secret key to use for the admin password |
+| currents.elastic.apiUser.secretName | string | `""` | The k8s secret to use for the elasticsearch api key |
+| currents.elastic.host | string | `""` | The elasticsearch host to use |
+| currents.objectStorage.endpoint | string | `""` | The object storage endpoint to use |
+| currents.objectStorage.secretName | string | `""` | The K8s secret to use for the object storage access key |
+| currents.objectStorage.bucket | string | `""` | The object storage bucket to use |
+| currents.mongoConnection.secretName | string | `""` | The K8s secret to use for the MongoDB connection string |
+| currents.mongoConnection.key | string | `""` | The K8s secret key to use for the MongoDB connection string |
+| currents.gitlab.state.secretName | string | `""` | The K8s secret to use for the GitLab state key |
+| currents.gitlab.state.secretKey | string | `""` | The K8s secret key to use for the GitLab state key |
+| redis.enabled | bool | `false` | enable the Bitnami Redis chart. Refer to https://github.com/bitnami/charts/blob/main/bitnami/redis/ for possible values. |
+
+### Frequently Used
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| currents.domains.https | bool | `true` | Whether to use https or http |
+| currents.email.smtp.secretUserKey | string | `"username"` | The K8s secret key to use for the SMTP username |
+| currents.email.smtp.secretPasswordKey | string | `"password"` | The K8s secret key to use for the SMTP password |
+| currents.apiJwtToken.key | string | `"token"` | The K8s secret key to use for the JWT token |
+| currents.apiInternalToken.key | string | `"token"` | The K8s secret key to use for the internal API token |
+| currents.elastic.admin.username | string | `"elastic"` | The elasticsearch admin username (used to manage the indexes) |
+| currents.elastic.apiUser.idKey | string | `"apiId"` | The k8s secret key to use for the elasticsearch api ID |
+| currents.elastic.apiUser.secretKey | string | `"apiKey"` | The k8s secret key to use for the elasticsearch api key |
+| currents.elastic.tls.enabled | bool | `true` | Whether to use TLS for the elasticsearch connection |
+| currents.objectStorage.secretIdKey | string | `"keyId"` | The K8s secret key to use for the object storage access key ID |
+| currents.objectStorage.secretAccessKey | string | `"keySecret"` | The K8s secret key to use for the object storage secret access key |
+| global.imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images. [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). |
+| director.resources | object | `{}` | Resources to provide [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| director.ingress.enabled | bool | `false` (but can also be turned on by currents.ingress.enabled) | Whether to enable the director ingress |
+| director.ingress.className | string | `""` | The ingress class to use |
+| director.ingress.annotations | object | `{}` | Annotations to add to the ingress |
+| director.ingress.hosts | list | see [values.yaml] for default values | The hosts to use for the ingress |
+| director.ingress.tls | list | see [values.yaml] for default values | The TLS configuration for the ingress |
+| server.resources | object | `{}` | Resources to provide [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| server.ingress.enabled | bool | `false` (but can also be turned on by currents.ingress.enabled) | Whether to enable the server ingress |
+| server.ingress.className | string | `""` | The ingress class to use |
+| server.ingress.annotations | object | `{}` | Annotations to add to the ingress |
+| server.ingress.hosts | list | see [values.yaml] for default values | The hosts to use for the ingress |
+| server.ingress.tls | list | see [values.yaml] for default values | The TLS configuration for the ingress |
+| writer.resources | object | `{}` (defaults to global.resources) | Resources to provide [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| scheduler.resources | object | `{}` (defaults to global.resources) | Resources to provide [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| changestreams.resources | object | `{}` (defaults to global.resources) | Resources to provide [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| webhooks.resources | object | `{}` (defaults to global.resources) | Resources to provide [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+
+### Other Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| currents.rootUser.email | string | `"admin@{{ .Values.currents.domains.appHost }}"` | The email address of the root user |
+| currents.imageTag | string | `"2025-04-08-001"` | The image tag to use for the Currents images |
+| currents.email.smtp.port | int | `587` | The SMTP server port to use |
+| currents.email.smtp.from | tpl/string | `"Currents Report <report@{{ .Values.currents.domains.appHost }}>"` | The email address to send from |
+| currents.email.smtp.tls | bool | `false` | Whether the SMTP server uses TLS |
+| currents.ingress.enabled | bool | `false` | Whether to enable the both default ingresses (server, and director) |
+| currents.apiJwtToken.expiry | string | `"1d"` | How often to expire session tokens signed by the JWT token  |
+| currents.redis.host | tpl | `{{ .Release.Name }}-redis-master` | set the redis hostname to talk to |
+| currents.elastic.datastreams.instances | string | `"currents_dev_instances"` | The elasticsearch index to use for instances |
+| currents.elastic.datastreams.tests | string | `"currents_dev_tests"` | The elasticsearch index to use for tests |
+| currents.elastic.datastreams.runs | string | `"currents_dev_runs"` | The elasticsearch index to use for runs |
+| currents.elastic.port | int | `9200` | The elasticsearch port to use |
+| currents.objectStorage.internalEndpoint | string | `""` | The object storage internal endpoint to use (for internal communication) |
+| currents.objectStorage.pathStyle | bool | `false` | Whether to use path style access for the object storage |
+| currents.logger.apiEndpoint | string | `""` | The coralogix API endpoint to use |
+| currents.logger.apiSecretName | string | `""` | The k8s secret to use for the coralogix private key |
+| currents.logger.apiSecretKey | string | `"apiKey"` | The k8s secret key to use for the coralogix private key |
+| global.imagePullPolicy | string | `"IfNotPresent"` | The image pull policy to use for all images |
+| global.additionalLabels | object | `{}` | Labels to apply to all resources. |
+| global.podAnnotations | object | `{}` | This is for setting Kubernetes Annotations to a Pod |
+| global.env | list | `[]` | Additional environment variables to pass to binary. |
+| global.containerSecurityContext | dict | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Container Security Context to be set on the pods [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
+| global.securityContext | dict | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch","runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod Security Context. [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
+| global.revisionHistoryLimit | string | `nil` | The number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10). |
+| global.priorityClassName | string | `""` | The optional priority class to be used for the currents pods. |
+| global.volumes | list | `[]` | Additional volumes on the output Deployment definition. |
+| global.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
+| global.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | This default ensures that Pods are only scheduled to Linux nodes. It prevents Pods being scheduled to Windows nodes in a mixed OS cluster. |
+| global.tolerations | list | `[]` |  |
+| global.affinity | object | `{}` |  |
+| director.name | string | `"director"` |  |
+| director.replicas | int | `1` |  |
+| director.image.registry | string | `"513558712013.dkr.ecr.us-east-1.amazonaws.com"` | The container registry to pull the manager image from. |
+| director.image.repository | string | `"currents/on-prem/director"` | The container image for Currents Director. |
+| director.image.tag | string | `""` | Override the image tag to deploy by setting this variable. |
+| director.image.digest | string | `""` | Setting a digest will override any tag. |
+| director.image.pullPolicy | string | `""` | default to the same as global.image.pullPolicy |
+| director.deploymentStrategy | object | `{}` | Deployment update strategy for Currents deployment. [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| director.env | list | `[]` | Env variables to pass to the container |
+| director.volumes | list | `[]` | Additional volumes on the output Deployment definition. |
+| director.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
+| director.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Liveness probe to check if the container is alive |
+| director.readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Readiness probe to check if the container is ready |
+| director.nodeSelector | object | `{}` (defaults to global.nodeSelector) | [Node selector] |
+| director.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
+| director.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| director.service | object | `{"port":1234,"type":"ClusterIP"}` | This is for setting up a service [more information](https://kubernetes.io/docs/concepts/services-networking/service/) |
+| server.name | string | `"server"` |  |
+| server.replicas | int | `1` |  |
+| server.image.registry | string | `"513558712013.dkr.ecr.us-east-1.amazonaws.com"` | The container registry to pull the manager image from |
+| server.image.repository | string | `"currents/on-prem/api"` | The container image for Currents Server API |
+| server.image.tag | string | `""` | Override the image tag to deploy by setting this variable |
+| server.image.digest | string | `""` | Setting a digest will override any tag |
+| server.image.pullPolicy | string | `""` | defaults to global.image.pullPolicy |
+| server.deploymentStrategy | object | `{}` | Deployment update strategy for Currents deployment |
+| server.env | list | `[]` | Env variables to pass to the container |
+| server.volumes | list | `[]` | Additional volumes on the output Deployment definition |
+| server.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition |
+| server.livenessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Liveness probe to check if the container is alive |
+| server.readinessProbe | object | `{"httpGet":{"path":"/","port":"http"}}` | Readiness probe to check if the container is ready |
+| server.nodeSelector | object | `{}` (defaults to global.nodeSelector) | [Node selector] |
+| server.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
+| server.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| server.service | object | `{"port":4000,"type":"ClusterIP"}` | This is for setting up a service [more information](https://kubernetes.io/docs/concepts/services-networking/service/) |
+| writer.name | string | `"writer"` |  |
+| writer.replicas | int | `1` |  |
+| writer.image.registry | string | `"513558712013.dkr.ecr.us-east-1.amazonaws.com"` |  |
+| writer.image.repository | string | `"currents/on-prem/writer"` |  |
+| writer.image.tag | string | `""` | Override the image tag to deploy by setting this variable |
+| writer.image.digest | string | `""` | Setting a digest will override any tag |
+| writer.image.pullPolicy | string | `""` | defaults to global.image.pullPolicy |
+| writer.deploymentStrategy | object | `{}` | Deployment update strategy for Currents deployment |
+| writer.env | list | `[]` | Env variables to pass to the container |
+| writer.volumes | list | `[]` | Additional volumes on the output Deployment definition |
+| writer.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition |
+| writer.livenessProbe | object | `{"exec":{"command":["./node_modules/.bin/pm2","show","writer-service"]}}` | Liveness probe to check if the container is alive |
+| writer.readinessProbe | object | `{"exec":{"command":["./node_modules/.bin/pm2","show","writer-service"]}}` | Readiness probe to check if the container is ready |
+| writer.nodeSelector | object | `{}` (defaults to global.nodeSelector) | [Node selector] |
+| writer.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
+| writer.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| scheduler.name | string | `"scheduler"` |  |
+| scheduler.image.registry | string | `"513558712013.dkr.ecr.us-east-1.amazonaws.com"` | The container registry to pull the manager image from |
+| scheduler.image.repository | string | `"currents/on-prem/scheduler"` | The container image for Currents Server API |
+| scheduler.image.tag | string | `""` | Override the image tag to deploy by setting this variable |
+| scheduler.image.digest | string | `""` | Setting a digest will override any tag |
+| scheduler.image.pullPolicy | string | `""` | defaults to global.image.pullPolicy |
+| scheduler.startup.persistence | object | See [values.yaml] for default values | Persistence settings used to optimize startup tasks (avoid rerun startup tasks on restart) |
+| scheduler.deploymentStrategy | object | `{"type":"Recreate"}` | Deployment update strategy for Currents deployment. [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| scheduler.env | list | `[]` | Env variables to pass to the container |
+| scheduler.volumes | list | `[]` | Additional volumes on the output Deployment definition |
+| scheduler.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition |
+| scheduler.livenessProbe | object | `{"exec":{"command":["./node_modules/.bin/pm2","show","dist"]}}` | Liveness probe to check if the container is alive |
+| scheduler.readinessProbe | object | `{"exec":{"command":["./node_modules/.bin/pm2","show","dist"]}}` | Readiness probe to check if the container is ready |
+| scheduler.nodeSelector | object | `{}` (defaults to global.nodeSelector) | [Node selector] |
+| scheduler.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
+| scheduler.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| changestreams.name | string | `"change-streams"` |  |
+| changestreams.image.registry | string | `"513558712013.dkr.ecr.us-east-1.amazonaws.com"` | The container registry to pull the manager image from. |
+| changestreams.image.repository | string | `"currents/on-prem/change-streams"` | The container image for Currents Change Streams Image |
+| changestreams.image.tag | string | `""` | Override the image tag to deploy by setting this variable |
+| changestreams.image.digest | string | `""` | Setting a digest will override any tag |
+| changestreams.image.pullPolicy | string | `""` | defaults to global.image.pullPolicy |
+| changestreams.deploymentStrategy | object | `{"type":"Recreate"}` | Deployment update strategy for Currents deployment. [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| changestreams.env | list | `[]` | Env variables to pass to the container |
+| changestreams.volumes | list | `[]` | Additional volumes on the output Deployment definition |
+| changestreams.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition |
+| changestreams.nodeSelector | object | `{}` (defaults to global.nodeSelector) | [Node selector] |
+| changestreams.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
+| changestreams.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| webhooks.name | string | `"webhooks"` |  |
+| webhooks.image.registry | string | `"513558712013.dkr.ecr.us-east-1.amazonaws.com"` |  |
+| webhooks.image.repository | string | `"currents/on-prem/webhooks"` |  |
+| webhooks.image.tag | string | `""` | Override the image tag to deploy by setting this variable |
+| webhooks.image.digest | string | `""` | Setting a digest will override any tag |
+| webhooks.image.pullPolicy | string | `""` | defaults to global.image.pullPolicy |
+| webhooks.deploymentStrategy | object | `{"type":"Recreate"}` | Deployment update strategy for Currents deployment. [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| webhooks.env | list | `[]` | Env variables to pass to the container |
+| webhooks.volumes | list | `[]` | Additional volumes on the output Deployment definition |
+| webhooks.volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition |
+| webhooks.livenessProbe | object | `{"exec":{"command":["./node_modules/.bin/pm2","show","dist"]}}` | Liveness probe to check if the container is alive |
+| webhooks.readinessProbe | object | `{"exec":{"command":["./node_modules/.bin/pm2","show","dist"]}}` | Readiness probe to check if the container is ready |
+| webhooks.nodeSelector | object | `{}` (defaults to global.nodeSelector) | [Node selector] |
+| webhooks.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
+| webhooks.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | If not set and create is true, a name is generated using the fullname template | The name of the service account to use. |
+| serviceAccount.annotations | object | `{}` | Optional additional annotations to add to the Service Account. Templates are allowed for both keys and values. |
+| serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
+| redis.image.repository | string | `"redis/redis-stack-server"` |  |
+| redis.image.tag | string | `"7.2.0-v15"` |  |
+| redis.commonConfiguration | string | `"loadmodule /opt/redis-stack/lib/rejson.so"` |  |
+| redis.architecture | string | `"standalone"` |  |
+| redis.auth.enabled | bool | `false` |  |
+| redis.master.resourcesPreset | string | `"none"` |  |
+| redis.replica.resourcesPreset | string | `"none"` |  |
+| redis.sentinel.resourcesPreset | string | `"none"` |  |
+| redis.metrics.resourcesPreset | string | `"none"` |  |
+| redis.volumePermissions.resourcesPreset | string | `"none"` |  |
+| redis.sysctl.resourcesPreset | string | `"none"` |  |

--- a/docs/configuration.md.gotmpl
+++ b/docs/configuration.md.gotmpl
@@ -10,3 +10,5 @@
 The following table lists the configurable parameters of the `currents` chart and their default values:
 
 {{ template "chart.valuesSection" . }}
+
+[values.yaml]: https://github.com/currents-dev/helm-charts/blob/main/charts/currents/values.yaml

--- a/docs/configuration.md.gotmpl
+++ b/docs/configuration.md.gotmpl
@@ -1,0 +1,12 @@
+# Configuration Reference
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+The following table lists the configurable parameters of the `currents` chart and their default values:
+
+{{ template "chart.valuesSection" . }}

--- a/docs/eks/README.md
+++ b/docs/eks/README.md
@@ -1,3 +1,4 @@
 # Installing the Currents Helm Chart on EKS
 
 - [Quickstart](./quickstart.md)
+- [Configuration Reference](../configuration.md)

--- a/docs/eks/quickstart.md
+++ b/docs/eks/quickstart.md
@@ -60,6 +60,8 @@ Configure and install the Currents Helm Chart once all the services are ready.
    - `server.ingress.annotations`
    - `server.ingress.hosts`
 
+   Also see the full [Configuration Reference](../configuration.md)
+
    Here is the sample config file
 
    `currents-helm-config.yaml`

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest -t docs/configuration.md.gotmpl -s file -o ../../docs/configuration.md

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -35,3 +35,7 @@ if [ -n "$VERSION" ]; then
   yq -i ".version = \"$VERSION\"" charts/currents/Chart.yaml
   echo "Updated version to $VERSION"
 fi
+
+# Call build-docs.sh script using a relative path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/build-docs.sh"


### PR DESCRIPTION
- Added helm-doc comments to the values.yaml so we can use the values.yaml file to generate the configuration file
- Adds a build-docs.sh script that runs the docs
- Adds a docs-check github workflow action to catch when it was failed to be run

A future followup would be to add a pre-commit hook, but that requires us add an install step. (adding a package.json and husky for node support)