### PR TITLE
[CSR-2497] fix: enable s3 region to be configured

### DIFF
--- a/charts/currents/templates/_common.tpl
+++ b/charts/currents/templates/_common.tpl
@@ -123,6 +123,10 @@ Create the name of the service account to use
   value: {{ .Values.currents.objectStorage.bucket }}
 - name: FILE_STORAGE_ENDPOINT
   value: {{ .Values.currents.objectStorage.endpoint }}
+{{- if .Values.currents.objectStorage.region }}
+- name: FILE_STORAGE_REGION
+  value: {{ .Values.currents.objectStorage.region }}
+{{- end }}
 {{- if .Values.currents.objectStorage.secretName }}
 - name: FILE_STORAGE_ACCESS_KEY_ID
   valueFrom:

--- a/charts/currents/values.yaml
+++ b/charts/currents/values.yaml
@@ -107,6 +107,8 @@ currents:
     endpoint: ""
     # -- The object storage internal endpoint to use (for internal communication)
     internalEndpoint: ""
+    # -- The region to use for the object storage
+    region: ""
     # -- The K8s secret to use for the object storage access key
     # @section -- Required
     secretName: ""

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -140,15 +140,9 @@ kubectl create secret docker-registry currents-pull-secret \
   kubectl apply -f -
 ```
 
-Create JWT secret
-
+Create required secrets for JWT auth and internal api
 ```sh
 kubectl create secret generic currents-api-jwt-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
-```
-
-Create internal API secret
-
-```sh
 kubectl create secret generic currents-api-internal-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
 ```
 

--- a/docs/eks/quickstart.md
+++ b/docs/eks/quickstart.md
@@ -90,6 +90,8 @@ Configure and install the Currents Helm Chart once all the services are ready.
        endpoint: https://s3.us-east-1.amazonaws.com
        # Enter your bucket name
        bucket: currents-my-org-name
+       # Enter your region
+       region: us-east-1
        secretName: currents-storage-user
        # Use the following settings instead if you setup Minio
        # Set the endpoint to your Minio Route


### PR DESCRIPTION
Configuration for region was somehow missed during earlier testing.

This results in our system defaulting to 'auto', which works for R2 but not for S3, for S3 the region needs to be set.