### PR TITLE
feat: Update the image tag to 2025-10-02-001

### DIFF
--- a/charts/currents/Chart.yaml
+++ b/charts/currents/Chart.yaml
@@ -5,10 +5,10 @@ home: https://currents.dev
 type: application
 # The chart version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 # Version number of the application being deployed.
 # Versions are not expected to follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "2025-06-10-001"
+appVersion: "2025-10-02-001"
 maintainers:
   - name: Currents-dev
     url: https://currents.dev

--- a/charts/currents/values.yaml
+++ b/charts/currents/values.yaml
@@ -20,7 +20,7 @@ currents:
     # -- The email address of the root user
     email: 'admin@{{ .Values.currents.domains.appHost }}'
   # -- The image tag to use for the Currents images
-  imageTag: 2025-06-10-001
+  imageTag: 2025-10-02-001
   email:
     smtp:
       # -- The SMTP server port to use

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025-06-10-001](https://img.shields.io/badge/AppVersion-2025--06--10--001-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025-10-02-001](https://img.shields.io/badge/AppVersion-2025--10--02--001-informational?style=flat-square)
 
 ## Requirements
 
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the `currents` chart an
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | currents.rootUser.email | string | `"admin@{{ .Values.currents.domains.appHost }}"` | The email address of the root user |
-| currents.imageTag | string | `"2025-06-10-001"` | The image tag to use for the Currents images |
+| currents.imageTag | string | `"2025-10-02-001"` | The image tag to use for the Currents images |
 | currents.email.smtp.port | int | `587` | The SMTP server port to use |
 | currents.email.smtp.from | tpl/string | `"Currents Report <report@{{ .Values.currents.domains.appHost }}>"` | The email address to send from |
 | currents.email.smtp.tls | bool | `false` | Whether the SMTP server uses TLS |


### PR DESCRIPTION
Prepare the next  release of the chart with updated images.

These images include:

- Support for Tagging tests in Currents Actions: https://currents.featurebase.app/changelog/action-engine-update-label-add-tags-error-condition
- A refreshed, more polished UI that brings consistent components, fonts and sizing among all the pages
- Security updates to dependencies

This is intended to be the last release that uses ElasticSearch for metrics and insights. The next release will include a swap to Clickhouse.