### PR TITLE
feat: Better auth

### DIFF
--- a/charts/currents/templates/_common.tpl
+++ b/charts/currents/templates/_common.tpl
@@ -171,6 +171,8 @@ Create the name of the service account to use
   value: {{ printf "%s/integrations/gitlab/callback" (include "currents.url" (dict "context" . "input" .Values.currents.domains.recordApiHost)) }}
 - name: APP_BASE_URL
   value: {{ include "currents.url" (dict "context" . "input"  .Values.currents.domains.appHost) }}
+- name: BETTER_AUTH_URL
+  value: {{ include "currents.url" (dict "context" . "input" .Values.currents.domains.appHost) }}
 - name: DASHBOARD_URL
   value: {{ include "currents.url" (dict "context" . "input" .Values.currents.domains.appHost) }}
 - name: CURRENTS_RECORD_API_URL
@@ -210,4 +212,24 @@ Create the name of the service account to use
   value: {{ include "currents.url" (dict "context" . "input" .Values.currents.domains.appHost) }}
 - name: AUTOMATED_REPORTS_EMAIL_FROM
   value: {{ tpl .Values.currents.email.smtp.from . }}
+{{- if .Values.currents.email.inviteFrom }}
+- name: INVITE_EMAIL_FROM
+  value: {{ tpl .Values.currents.email.inviteFrom . }}
+{{- end }}
+{{- if .Values.currents.email.inviteBcc }}
+- name: INVITE_EMAIL_BCC
+  value: {{ .Values.currents.email.inviteBcc }}
+{{- end }}
+{{- if .Values.currents.email.reportsBcc }}
+- name: AUTOMATED_REPORTS_EMAIL_BCC
+  value: {{ .Values.currents.email.reportsBcc }}
+{{- end }}
+{{- if .Values.currents.email.inviteExpirationDays }}
+- name: INVITE_EXPIRATION_DAYS
+  value: {{ .Values.currents.email.inviteExpirationDays | quote }}
+{{- end }}
+{{- if .Values.currents.email.linksBaseUrl }}
+- name: EMAIL_LINKS_BASE_URL
+  value: {{ .Values.currents.email.linksBaseUrl }}
+{{- end }}
 {{- end -}}

--- a/charts/currents/templates/server/deployment.yaml
+++ b/charts/currents/templates/server/deployment.yaml
@@ -56,19 +56,26 @@ spec:
                   name: {{ .Values.currents.gitlab.state.secretName }}
                   key: {{ .Values.currents.gitlab.state.secretKey }}
           {{- end }}
-            - name: JWT_SECRET_EXPIRY
-              value: {{ .Values.currents.apiJwtToken.expiry | quote }}
+            - name: BETTER_AUTH_ENABLED
+              value: "true"
             - name: ON_PREM_EMAIL
               value: {{ tpl .Values.currents.rootUser.email . }}
+          {{- if .Values.currents.rootUser.password.secretName }}
+            - name: ON_PREM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.currents.rootUser.password.secretName }}
+                  key: {{ .Values.currents.rootUser.password.key }}
+          {{- end }}
           {{- include "currents.connectionConfigEnv" . | nindent 12 }}
           {{- include "currents.URLConfigEnv" . | nindent 12 }}
           {{- include "currents.emailSMTPEnv" . | nindent 12 }}
-          {{- if .Values.currents.apiJwtToken.secretName }}
-            - name: JWT_SECRET
+          {{- if .Values.currents.betterAuth.secretName }}
+            - name: BETTER_AUTH_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.currents.apiJwtToken.secretName }}
-                  key: {{ .Values.currents.apiJwtToken.key }}
+                  name: {{ .Values.currents.betterAuth.secretName }}
+                  key: {{ .Values.currents.betterAuth.key }}
           {{- end }}
           {{- if .Values.currents.apiInternalToken.secretName }}
             - name: API_SECRET

--- a/charts/currents/values.yaml
+++ b/charts/currents/values.yaml
@@ -19,6 +19,13 @@ currents:
   rootUser:
     # -- The email address of the root user
     email: 'admin@{{ .Values.currents.domains.appHost }}'
+    password:
+      # -- The K8s secret containing the root user password. The password is used during initial setup only.
+      # @section -- Required
+      secretName: ""
+      # -- The K8s secret key for the root user password
+      # @section -- Frequently Used
+      key: password
   # -- The image tag to use for the Currents images
   imageTag: 2025-10-02-001
   email:
@@ -41,18 +48,26 @@ currents:
       secretName: ""
       # -- Whether the SMTP server uses TLS
       tls: false
+    # -- (tpl/string) The email address to send invitations from
+    inviteFrom: ""
+    # -- Number of days before invitation links expire
+    inviteExpirationDays: ""
+    # -- BCC address for automated report emails
+    reportsBcc: ""
+    # -- BCC address for invitation emails
+    inviteBcc: ""
+    # -- Base URL for links in emails (defaults to APP_BASE_URL if empty)
+    linksBaseUrl: ""
   ingress:
     # -- Whether to enable the both default ingresses (server, and director)
     enabled: false
-  apiJwtToken:
-    # -- The K8s secret to use for the JWT token
+  betterAuth:
+    # -- The K8s secret containing the Better Auth secret
     # @section -- Required
     secretName: ""
-    # -- The K8s secret key to use for the JWT token
+    # -- The K8s secret key for the Better Auth secret
     # @section -- Frequently Used
-    key: token
-    # -- How often to expire session tokens signed by the JWT token
-    expiry: 1d
+    key: secret
   apiInternalToken:
     # -- The K8s secret to use for the internal API token
     # @section -- Required

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,9 +18,10 @@ The following table lists the configurable parameters of the `currents` chart an
 |-----|------|---------|-------------|
 | currents.domains.appHost | string | `"currents-app.localhost"` | The host for the app |
 | currents.domains.recordApiHost | string | `"currents-record.localhost"` | The host for the recording endpoint that the test reporters communicate with |
+| currents.rootUser.password.secretName | string | `""` | The K8s secret containing the root user password. The password is used during initial setup only. |
 | currents.email.smtp.host | string | `""` | the SMTP server to use |
 | currents.email.smtp.secretName | string | `""` | K8s secret to use for the SMTP username/password |
-| currents.apiJwtToken.secretName | string | `""` | The K8s secret to use for the JWT token |
+| currents.betterAuth.secretName | string | `""` | The K8s secret containing the Better Auth secret |
 | currents.apiInternalToken.secretName | string | `""` | The K8s secret to use for the internal API token |
 | currents.clickhouse.user.secretName | string | `""` | The k8s secret to use for the ClickHouse password |
 | currents.clickhouse.user.secretPasswordKey | string | `""` | The k8s secret key to use to access the ClickHouse password |
@@ -40,9 +41,10 @@ The following table lists the configurable parameters of the `currents` chart an
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | currents.domains.https | bool | `true` | Whether to use https or http |
+| currents.rootUser.password.key | string | `"password"` | The K8s secret key for the root user password |
 | currents.email.smtp.secretUserKey | string | `"username"` | The K8s secret key to use for the SMTP username |
 | currents.email.smtp.secretPasswordKey | string | `"password"` | The K8s secret key to use for the SMTP password |
-| currents.apiJwtToken.key | string | `"token"` | The K8s secret key to use for the JWT token |
+| currents.betterAuth.key | string | `"secret"` | The K8s secret key for the Better Auth secret |
 | currents.apiInternalToken.key | string | `"token"` | The K8s secret key to use for the internal API token |
 | currents.clickhouse.user.username | string | `"currents"` | The ClickHouse username to use |
 | currents.clickhouse.tls.enabled | bool | `true` | Whether to use TLS for the ClickHouse connection |
@@ -75,8 +77,12 @@ The following table lists the configurable parameters of the `currents` chart an
 | currents.email.smtp.port | int | `587` | The SMTP server port to use |
 | currents.email.smtp.from | tpl/string | `"Currents Report <report@{{ .Values.currents.domains.appHost }}>"` | The email address to send from |
 | currents.email.smtp.tls | bool | `false` | Whether the SMTP server uses TLS |
+| currents.email.inviteFrom | tpl/string | `""` | The email address to send invitations from |
+| currents.email.inviteExpirationDays | string | `""` | Number of days before invitation links expire |
+| currents.email.reportsBcc | string | `""` | BCC address for automated report emails |
+| currents.email.inviteBcc | string | `""` | BCC address for invitation emails |
+| currents.email.linksBaseUrl | string | `""` | Base URL for links in emails (defaults to APP_BASE_URL if empty) |
 | currents.ingress.enabled | bool | `false` | Whether to enable the both default ingresses (server, and director) |
-| currents.apiJwtToken.expiry | string | `"1d"` | How often to expire session tokens signed by the JWT token |
 | currents.redis.host | tpl | `{{ .Release.Name }}-redis-master` | set the redis hostname to talk to |
 | currents.clickhouse.port | int | `8123` | The ClickHouse port to use |
 | currents.objectStorage.internalEndpoint | string | `""` | The object storage internal endpoint to use (for internal communication) |

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -110,10 +110,18 @@ kubectl create secret docker-registry currents-pull-secret \
   kubectl apply -f -
 ```
 
-Create required secrets for JWT auth and internal api
+Create required secrets for authentication and internal API
 ```sh
-kubectl create secret generic currents-api-jwt-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
-kubectl create secret generic currents-api-internal-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
+kubectl create secret generic currents-better-auth --from-literal=secret=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 64)
+kubectl create secret generic currents-api-internal-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 64)
+```
+
+Create root user password secret (used for initial admin account)
+```sh
+kubectl create secret generic currents-root-user --from-literal=password=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
+
+# To retrieve the generated password:
+kubectl get secret currents-root-user -o jsonpath='{.data.password}' | base64 -d
 ```
 
 Create a GitLab private encoding key

--- a/docs/eks/quickstart.md
+++ b/docs/eks/quickstart.md
@@ -40,10 +40,20 @@ See [Currents Service Dependencies](./dependencies.md).
 
 Configure and install the Currents Helm Chart once all the services are ready.
 
-1. Create required secrets for JWT auth and internal api
+1. Create required secrets for authentication and internal API
    ```sh
-   kubectl create secret generic currents-api-jwt-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
-   kubectl create secret generic currents-api-internal-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
+   # Better Auth secret (64 characters recommended)
+   kubectl create secret generic currents-better-auth --from-literal=secret=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 64)
+
+   # Internal API secret (for service-to-service auth)
+   kubectl create secret generic currents-api-internal-token --from-literal=token=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 64)
+
+   # Root user password (used for initial admin account)
+   # IMPORTANT: Save this password - you'll need it to log in the first time
+   kubectl create secret generic currents-root-user --from-literal=password=$(head -c 512 /dev/urandom | LC_ALL=C tr -cd 'a-zA-Z0-9' | head -c 32)
+
+   # To retrieve the generated password later:
+   # kubectl get secret currents-root-user -o jsonpath='{.data.password}' | base64 -d
    ```
 
 2. Create a config file for the Currents Helm Charts values
@@ -115,14 +125,17 @@ Configure and install the Currents Helm Chart once all the services are ready.
        # bucket: currents
        # pathStyle: true
 
-     gitlab:
-       state:
-         secretName: currents-gitlab-key 
-         secretKey: gitlab-key.pem 
-     apiJwtToken:
-       secretName: currents-api-jwt-token
-     apiInternalToken:
-       secretName: currents-api-internal-token
+    gitlab:
+      state:
+        secretName: currents-gitlab-key 
+        secretKey: gitlab-key.pem 
+    betterAuth:
+      secretName: currents-better-auth
+    rootUser:
+      password:
+        secretName: currents-root-user
+    apiInternalToken:
+      secretName: currents-api-internal-token
      mongoConnection:
        secretName: mongodb-currents-currents-user
        key: connectionString.standardSrv

--- a/samples/local/chart-config.yaml
+++ b/samples/local/chart-config.yaml
@@ -16,8 +16,11 @@ currents:
     appHost: currents-app.localhost
     recordApiHost: currents-record.localhost
   imageTag: staging
-  apiJwtToken:
-    secretName: currents-api-jwt-token
+  betterAuth:
+    secretName: currents-better-auth
+  rootUser:
+    password:
+      secretName: currents-root-user
   apiInternalToken:
     secretName: currents-api-internal-token
   gitlab:


### PR DESCRIPTION
## Commit Description

- Support multiple users in onPrem via username-password instead of trusted jwt
- Enable password creation for root user at setup time

## Summary

Migrates authentication from JWT-based tokens to Better Auth, adding support for root user password configuration and new email settings.

### Changes

- **Authentication Migration**: Replaced `apiJwtToken` configuration with `betterAuth` secret configuration
  - Removed `JWT_SECRET` and `JWT_SECRET_EXPIRY` environment variables
  - Added `BETTER_AUTH_SECRET` and `BETTER_AUTH_ENABLED` environment variables
  - Added `BETTER_AUTH_URL` pointing to the app host

- **Root User Password**: Added support for configuring root user password via Kubernetes secret
  - New `currents.rootUser.password.secretName` and `currents.rootUser.password.key` values
  - Injects `ON_PREM_PASSWORD` environment variable when configured

- **Email Configuration**: Added new optional email settings
  - `inviteFrom` - Custom sender address for invitation emails
  - `inviteBcc` - BCC address for invitation emails
  - `reportsBcc` - BCC address for automated report emails
  - `inviteExpirationDays` - Configurable invitation link expiration
  - `linksBaseUrl` - Custom base URL for email links

- **Documentation**: Updated developer guide and EKS quickstart with new secret creation commands
  - Increased recommended secret lengths from 32 to 64 characters for auth secrets

### Breaking Changes

- `currents.apiJwtToken.secretName` → `currents.betterAuth.secretName`
- `currents.apiJwtToken.key` → `currents.betterAuth.key` (default changed from `token` to `secret`)
- Removed `currents.apiJwtToken.expiry` (no longer applicable)

### Migration

Existing deployments need to:
1. Create a new `currents-better-auth` secret with a 64-character secret
2. Create a new `currents-root-user` secret with the admin password
3. Update Helm values to use `betterAuth` instead of `apiJwtToken`